### PR TITLE
feat: カテゴリ・通貨一覧APIの実装

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -3,6 +3,8 @@ import corsPlugin from "./plugins/cors.js";
 import errorHandlerPlugin from "./plugins/error-handler.js";
 import jwtPlugin from "./plugins/jwt.js";
 import { authRoutes } from "./routes/auth.js";
+import { categoryRoutes } from "./routes/categories.js";
+import { currencyRoutes } from "./routes/currencies.js";
 import { subscriptionRoutes } from "./routes/subscriptions.js";
 
 export function buildApp() {
@@ -18,6 +20,8 @@ export function buildApp() {
 	// ルート登録
 	fastify.register(authRoutes, { prefix: "/api/auth" });
 	fastify.register(subscriptionRoutes, { prefix: "/api/subscriptions" });
+	fastify.register(categoryRoutes, { prefix: "/api/categories" });
+	fastify.register(currencyRoutes, { prefix: "/api/currencies" });
 
 	// ヘルスチェック
 	fastify.get("/api/health", async () => {

--- a/packages/backend/src/routes/categories.ts
+++ b/packages/backend/src/routes/categories.ts
@@ -1,0 +1,22 @@
+import type { FastifyInstance } from "fastify";
+import type { Category } from "shared";
+import { prisma } from "../db.js";
+import { successResponse } from "../utils/response.js";
+
+export async function categoryRoutes(fastify: FastifyInstance) {
+	// GET /api/categories
+	fastify.get("/", async (_request, reply) => {
+		const categories = await prisma.category.findMany({
+			orderBy: { name: "asc" },
+		});
+
+		const data: Category[] = categories.map((c) => ({
+			id: c.id,
+			name: c.name,
+			createdAt: c.createdAt.toISOString(),
+			updatedAt: c.updatedAt.toISOString(),
+		}));
+
+		return reply.send(successResponse(data));
+	});
+}

--- a/packages/backend/src/routes/currencies.ts
+++ b/packages/backend/src/routes/currencies.ts
@@ -1,0 +1,23 @@
+import type { FastifyInstance } from "fastify";
+import type { Currency } from "shared";
+import { prisma } from "../db.js";
+import { successResponse } from "../utils/response.js";
+
+export async function currencyRoutes(fastify: FastifyInstance) {
+	// GET /api/currencies
+	fastify.get("/", async (_request, reply) => {
+		const currencies = await prisma.currency.findMany({
+			orderBy: { code: "asc" },
+		});
+
+		const data: Currency[] = currencies.map((c) => ({
+			id: c.id,
+			code: c.code,
+			name: c.name,
+			createdAt: c.createdAt.toISOString(),
+			updatedAt: c.updatedAt.toISOString(),
+		}));
+
+		return reply.send(successResponse(data));
+	});
+}


### PR DESCRIPTION
## Issue
Closed #19 

## 概要
- カテゴリ・通貨の一覧取得APIを実装
- フロントエンドのサブスクリプション登録・編集フォームで使用する選択肢データを提供する

## 変更内容
### 新規
- `src/routes/categories.ts`: `GET /api/categories` - カテゴリ一覧（名前昇順）
- `src/routes/currencies.ts`: `GET /api/currencies` - 通貨一覧（コード昇順）

### 変更
 - `src/app.ts`: 2ルートを `/api/categories`, `/api/currencies`プレフィックスで登録

## メモ
- 両エンドポイントとも認証不要（フォームの選択肢として誰でも参照可能）
- 読み取り専用のみ実装（カテゴリ・通貨のCRUDは管理画面想定のため対象外）