### PR TITLE
feat: サブスクリプションCRUD画面の実装 (#24・#25・#26)

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,6 +24,9 @@
 		"prisma": "^5.22.0",
 		"tsx": "^4.21.0"
 	},
+	"prisma": {
+		"seed": "tsx prisma/seed.ts"
+	},
 	"dependencies": {
 		"@fastify/cors": "^11.2.0",
 		"@fastify/jwt": "^10.0.0",

--- a/packages/backend/prisma/seed.ts
+++ b/packages/backend/prisma/seed.ts
@@ -1,0 +1,55 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+	// カテゴリのシードデータ
+	const categories = [
+		"エンタメ",
+		"音楽",
+		"動画",
+		"ゲーム",
+		"クラウドストレージ",
+		"ビジネス・生産性",
+		"ニュース・情報",
+		"学習・教育",
+		"フィットネス・健康",
+		"その他",
+	];
+
+	const categoryCount = await prisma.category.count();
+	if (categoryCount === 0) {
+		await prisma.category.createMany({
+			data: categories.map((name) => ({ name })),
+		});
+	}
+
+	// 通貨のシードデータ
+	const currencies = [
+		{ code: "JPY", name: "日本円" },
+		{ code: "USD", name: "米ドル" },
+		{ code: "EUR", name: "ユーロ" },
+		{ code: "GBP", name: "英ポンド" },
+		{ code: "AUD", name: "オーストラリアドル" },
+		{ code: "CAD", name: "カナダドル" },
+	];
+
+	for (const currency of currencies) {
+		await prisma.currency.upsert({
+			where: { code: currency.code },
+			update: {},
+			create: currency,
+		});
+	}
+
+	console.log("Seed completed.");
+}
+
+main()
+	.catch((e) => {
+		console.error(e);
+		process.exit(1);
+	})
+	.finally(async () => {
+		await prisma.$disconnect();
+	});

--- a/packages/backend/src/plugins/cors.ts
+++ b/packages/backend/src/plugins/cors.ts
@@ -6,6 +6,7 @@ async function corsPlugin(fastify: FastifyInstance) {
 	await fastify.register(cors, {
 		origin: true,
 		credentials: true,
+		methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
 	});
 }
 

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { isAuthenticated } from "./api/client.js";
 import { LoginPage } from "./pages/LoginPage.js";
 import { RegisterPage } from "./pages/RegisterPage.js";
+import { SubscriptionFormPage } from "./pages/SubscriptionFormPage.js";
 import { SubscriptionListPage } from "./pages/SubscriptionListPage.js";
 
 /** 未ログイン専用ルート：ログイン済みなら / にリダイレクト */
@@ -26,6 +27,14 @@ function App() {
 				<Route
 					path="/register"
 					element={<GuestRoute element={<RegisterPage />} />}
+				/>
+				<Route
+					path="/subscriptions/new"
+					element={<PrivateRoute element={<SubscriptionFormPage />} />}
+				/>
+				<Route
+					path="/subscriptions/:id/edit"
+					element={<PrivateRoute element={<SubscriptionFormPage />} />}
 				/>
 				<Route path="*" element={<Navigate to="/" replace />} />
 			</Routes>

--- a/packages/frontend/src/api/categories.ts
+++ b/packages/frontend/src/api/categories.ts
@@ -1,0 +1,6 @@
+import type { Category } from "shared";
+import { apiClient } from "./client.js";
+
+export const categoriesApi = {
+	list: () => apiClient.get<Category[]>("/api/categories"),
+};

--- a/packages/frontend/src/api/client.ts
+++ b/packages/frontend/src/api/client.ts
@@ -26,7 +26,7 @@ async function request<T>(
 	const token = getToken();
 
 	const headers: HeadersInit = {
-		"Content-Type": "application/json",
+		...(options.body ? { "Content-Type": "application/json" } : {}),
 		...(token ? { Authorization: `Bearer ${token}` } : {}),
 		...options.headers,
 	};

--- a/packages/frontend/src/api/currencies.ts
+++ b/packages/frontend/src/api/currencies.ts
@@ -1,0 +1,6 @@
+import type { Currency } from "shared";
+import { apiClient } from "./client.js";
+
+export const currenciesApi = {
+	list: () => apiClient.get<Currency[]>("/api/currencies"),
+};

--- a/packages/frontend/src/pages/SubscriptionFormPage.module.css
+++ b/packages/frontend/src/pages/SubscriptionFormPage.module.css
@@ -1,0 +1,100 @@
+.container {
+	max-width: 560px;
+	margin: 2rem auto;
+	padding: 0 1rem;
+}
+
+.container h1 {
+	font-size: 1.5rem;
+	margin-bottom: 1.5rem;
+}
+
+.form {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.field {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.field label {
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: #374151;
+}
+
+.field input,
+.field select {
+	padding: 0.5rem 0.75rem;
+	border: 1px solid #d1d5db;
+	border-radius: 6px;
+	font-size: 1rem;
+	background: #fff;
+}
+
+.field input:focus,
+.field select:focus {
+	outline: none;
+	border-color: #6366f1;
+	box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.fieldInline {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.fieldInline label {
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: #374151;
+}
+
+.error {
+	color: #dc2626;
+	font-size: 0.875rem;
+	margin-bottom: 0.5rem;
+}
+
+.actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 0.75rem;
+	margin-top: 0.5rem;
+}
+
+.actions button {
+	padding: 0.5rem 1.25rem;
+	border-radius: 6px;
+	font-size: 1rem;
+	cursor: pointer;
+	border: none;
+}
+
+.actions button[type="button"] {
+	background: #f3f4f6;
+	color: #374151;
+}
+
+.actions button[type="button"]:hover {
+	background: #e5e7eb;
+}
+
+.actions button[type="submit"] {
+	background: #6366f1;
+	color: #fff;
+}
+
+.actions button[type="submit"]:hover:not(:disabled) {
+	background: #4f46e5;
+}
+
+.actions button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}

--- a/packages/frontend/src/pages/SubscriptionFormPage.tsx
+++ b/packages/frontend/src/pages/SubscriptionFormPage.tsx
@@ -1,0 +1,291 @@
+import { useEffect, useId, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import type { BillingCycle, Category, Currency } from "shared";
+import { categoriesApi } from "../api/categories.js";
+import { currenciesApi } from "../api/currencies.js";
+import { subscriptionsApi } from "../api/subscriptions.js";
+import styles from "./SubscriptionFormPage.module.css";
+
+interface FormValues {
+	name: string;
+	price: string;
+	currencyId: string;
+	billingCycle: BillingCycle;
+	startDate: string;
+	nextRenewalDate: string;
+	notifyBefore: string;
+	isActive: boolean;
+	categoryId: string;
+}
+
+const defaultValues: FormValues = {
+	name: "",
+	price: "",
+	currencyId: "",
+	billingCycle: "monthly",
+	startDate: "",
+	nextRenewalDate: "",
+	notifyBefore: "3",
+	isActive: true,
+	categoryId: "",
+};
+
+export function SubscriptionFormPage() {
+	const { id } = useParams<{ id: string }>();
+	const isEdit = id !== undefined;
+	const navigate = useNavigate();
+
+	const [values, setValues] = useState<FormValues>(defaultValues);
+	const [categories, setCategories] = useState<Category[]>([]);
+	const [currencies, setCurrencies] = useState<Currency[]>([]);
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(isEdit);
+
+	const uid = useId();
+	const nameId = `${uid}-name`;
+	const priceId = `${uid}-price`;
+	const currencyId = `${uid}-currencyId`;
+	const billingCycleId = `${uid}-billingCycle`;
+	const startDateId = `${uid}-startDate`;
+	const nextRenewalDateId = `${uid}-nextRenewalDate`;
+	const categoryIdId = `${uid}-categoryId`;
+	const notifyBeforeId = `${uid}-notifyBefore`;
+	const isActiveId = `${uid}-isActive`;
+
+	useEffect(() => {
+		const fetchMeta = async () => {
+			const [catResult, curResult] = await Promise.all([
+				categoriesApi.list(),
+				currenciesApi.list(),
+			]);
+			if (catResult.success) setCategories(catResult.data);
+			if (curResult.success) setCurrencies(curResult.data);
+		};
+		fetchMeta();
+	}, []);
+
+	useEffect(() => {
+		if (!isEdit || !id) return;
+
+		const fetchSubscription = async () => {
+			const result = await subscriptionsApi.get(id);
+			setLoading(false);
+
+			if (!result.success) {
+				setError(result.error);
+				return;
+			}
+
+			const sub = result.data;
+			setValues({
+				name: sub.name,
+				price: sub.price,
+				currencyId: sub.currencyId !== null ? String(sub.currencyId) : "",
+				billingCycle: sub.billingCycle,
+				startDate: sub.startDate,
+				nextRenewalDate: sub.nextRenewalDate,
+				notifyBefore: String(sub.notifyBefore),
+				isActive: sub.isActive,
+				categoryId: sub.categoryId !== null ? String(sub.categoryId) : "",
+			});
+		};
+
+		fetchSubscription();
+	}, [id, isEdit]);
+
+	const handleChange = (
+		e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+	) => {
+		const { name, value, type } = e.target;
+		if (type === "checkbox") {
+			setValues((prev) => ({
+				...prev,
+				[name]: (e.target as HTMLInputElement).checked,
+			}));
+		} else {
+			setValues((prev) => ({ ...prev, [name]: value }));
+		}
+	};
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setSubmitting(true);
+		setError(null);
+
+		const payload = {
+			name: values.name,
+			price: values.price,
+			currencyId: values.currencyId ? Number(values.currencyId) : null,
+			billingCycle: values.billingCycle,
+			startDate: values.startDate,
+			nextRenewalDate: values.nextRenewalDate,
+			notifyBefore: Number(values.notifyBefore),
+			isActive: values.isActive,
+			categoryId: values.categoryId ? Number(values.categoryId) : null,
+		};
+
+		const result =
+			isEdit && id
+				? await subscriptionsApi.update(id, payload)
+				: await subscriptionsApi.create(payload);
+
+		setSubmitting(false);
+
+		if (!result.success) {
+			setError(result.error);
+			return;
+		}
+
+		navigate("/");
+	};
+
+	if (loading) return <p>読み込み中...</p>;
+
+	return (
+		<div className={styles.container}>
+			<h1>
+				{isEdit ? "サブスクリプションを編集" : "サブスクリプションを追加"}
+			</h1>
+
+			{error && <p className={styles.error}>{error}</p>}
+
+			<form onSubmit={handleSubmit} className={styles.form}>
+				<div className={styles.field}>
+					<label htmlFor={nameId}>サービス名</label>
+					<input
+						id={nameId}
+						name="name"
+						type="text"
+						value={values.name}
+						onChange={handleChange}
+						required
+					/>
+				</div>
+
+				<div className={styles.field}>
+					<label htmlFor={priceId}>金額</label>
+					<input
+						id={priceId}
+						name="price"
+						type="text"
+						inputMode="decimal"
+						value={values.price}
+						onChange={handleChange}
+						required
+					/>
+				</div>
+
+				<div className={styles.field}>
+					<label htmlFor={currencyId}>通貨</label>
+					<select
+						id={currencyId}
+						name="currencyId"
+						value={values.currencyId}
+						onChange={handleChange}
+					>
+						<option value="">選択してください</option>
+						{currencies.map((c) => (
+							<option key={c.id} value={String(c.id)}>
+								{c.code} - {c.name}
+							</option>
+						))}
+					</select>
+				</div>
+
+				<div className={styles.field}>
+					<label htmlFor={billingCycleId}>請求サイクル</label>
+					<select
+						id={billingCycleId}
+						name="billingCycle"
+						value={values.billingCycle}
+						onChange={handleChange}
+						required
+					>
+						<option value="monthly">月額</option>
+						<option value="yearly">年額</option>
+					</select>
+				</div>
+
+				<div className={styles.field}>
+					<label htmlFor={startDateId}>開始日</label>
+					<input
+						id={startDateId}
+						name="startDate"
+						type="date"
+						value={values.startDate}
+						onChange={handleChange}
+						required
+					/>
+				</div>
+
+				<div className={styles.field}>
+					<label htmlFor={nextRenewalDateId}>次回更新日</label>
+					<input
+						id={nextRenewalDateId}
+						name="nextRenewalDate"
+						type="date"
+						value={values.nextRenewalDate}
+						onChange={handleChange}
+						required
+					/>
+				</div>
+
+				<div className={styles.field}>
+					<label htmlFor={categoryIdId}>カテゴリ</label>
+					<select
+						id={categoryIdId}
+						name="categoryId"
+						value={values.categoryId}
+						onChange={handleChange}
+					>
+						<option value="">選択してください</option>
+						{categories.map((c) => (
+							<option key={c.id} value={String(c.id)}>
+								{c.name}
+							</option>
+						))}
+					</select>
+				</div>
+
+				<div className={styles.field}>
+					<label htmlFor={notifyBeforeId}>更新通知（日前）</label>
+					<input
+						id={notifyBeforeId}
+						name="notifyBefore"
+						type="number"
+						min="0"
+						max="30"
+						value={values.notifyBefore}
+						onChange={handleChange}
+						required
+					/>
+				</div>
+
+				<div className={styles.fieldInline}>
+					<input
+						id={isActiveId}
+						name="isActive"
+						type="checkbox"
+						checked={values.isActive}
+						onChange={handleChange}
+					/>
+					<label htmlFor={isActiveId}>有効</label>
+				</div>
+
+				<div className={styles.actions}>
+					<button
+						type="button"
+						onClick={() => navigate("/")}
+						disabled={submitting}
+					>
+						キャンセル
+					</button>
+					<button type="submit" disabled={submitting}>
+						{submitting ? "保存中..." : isEdit ? "更新する" : "登録する"}
+					</button>
+				</div>
+			</form>
+		</div>
+	);
+}

--- a/packages/frontend/src/pages/SubscriptionListPage.module.css
+++ b/packages/frontend/src/pages/SubscriptionListPage.module.css
@@ -1,0 +1,109 @@
+.container {
+	max-width: 720px;
+	margin: 2rem auto;
+	padding: 0 1rem;
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 1.5rem;
+}
+
+.header h1 {
+	font-size: 1.5rem;
+	margin: 0;
+}
+
+.addButton {
+	padding: 0.5rem 1.25rem;
+	background: #6366f1;
+	color: #fff;
+	border: none;
+	border-radius: 6px;
+	font-size: 1rem;
+	cursor: pointer;
+}
+
+.addButton:hover {
+	background: #4f46e5;
+}
+
+.empty {
+	color: #6b7280;
+	text-align: center;
+	margin-top: 3rem;
+}
+
+.list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
+.item {
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+	padding: 1rem;
+	background: #fff;
+	border: 1px solid #e5e7eb;
+	border-radius: 8px;
+}
+
+.info {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.name {
+	font-weight: 600;
+	font-size: 1rem;
+}
+
+.meta {
+	font-size: 0.875rem;
+	color: #6b7280;
+}
+
+.itemActions {
+	display: flex;
+	gap: 0.5rem;
+}
+
+.editButton,
+.deleteButton {
+	padding: 0.375rem 0.875rem;
+	border: none;
+	border-radius: 6px;
+	font-size: 0.875rem;
+	cursor: pointer;
+}
+
+.editButton {
+	background: #f3f4f6;
+	color: #374151;
+}
+
+.editButton:hover {
+	background: #e5e7eb;
+}
+
+.deleteButton {
+	background: #fee2e2;
+	color: #dc2626;
+}
+
+.deleteButton:hover {
+	background: #fecaca;
+}
+
+.error {
+	color: #dc2626;
+}

--- a/packages/frontend/src/pages/SubscriptionListPage.tsx
+++ b/packages/frontend/src/pages/SubscriptionListPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { SubscriptionWithRelations } from "shared";
 import { subscriptionsApi } from "../api/subscriptions.js";
+import styles from "./SubscriptionListPage.module.css";
 
 export function SubscriptionListPage() {
 	const [subscriptions, setSubscriptions] = useState<
@@ -11,50 +12,90 @@ export function SubscriptionListPage() {
 	const [error, setError] = useState<string | null>(null);
 	const navigate = useNavigate();
 
-	useEffect(() => {
-		const fetchSubscriptions = async () => {
-			const result = await subscriptionsApi.list();
-			setLoading(false);
+	const fetchSubscriptions = useCallback(async () => {
+		const result = await subscriptionsApi.list();
+		setLoading(false);
 
-			if (!result.success) {
-				setError(result.error);
-				if (result.error === "認証が必要です") {
-					navigate("/login");
-				}
-				return;
+		if (!result.success) {
+			setError(result.error);
+			if (result.error === "認証が必要です") {
+				navigate("/login");
 			}
+			return;
+		}
 
-			setSubscriptions(result.data.subscriptions);
-		};
-
-		fetchSubscriptions();
+		setSubscriptions(result.data.subscriptions);
 	}, [navigate]);
 
+	useEffect(() => {
+		fetchSubscriptions();
+	}, [fetchSubscriptions]);
+
+	const handleDelete = async (id: string) => {
+		if (!window.confirm("このサブスクリプションを削除しますか？")) return;
+
+		const result = await subscriptionsApi.delete(id);
+		if (!result.success) {
+			alert(result.error);
+			return;
+		}
+
+		setSubscriptions((prev) => prev.filter((s) => s.id !== id));
+	};
+
 	if (loading) return <p>読み込み中...</p>;
-	if (error) return <p>{error}</p>;
 
 	return (
-		<div>
-			<h1>サブスクリプション一覧</h1>
-			<button type="button" onClick={() => navigate("/subscriptions/new")}>
-				+ 新規追加
-			</button>
+		<div className={styles.container}>
+			<div className={styles.header}>
+				<h1>サブスクリプション一覧</h1>
+				<button
+					type="button"
+					className={styles.addButton}
+					onClick={() => navigate("/subscriptions/new")}
+				>
+					+ 新規追加
+				</button>
+			</div>
+
+			{error && <p className={styles.error}>{error}</p>}
+
 			{subscriptions.length === 0 ? (
-				<p>登録されているサブスクリプションはありません</p>
+				<p className={styles.empty}>
+					登録されているサブスクリプションはありません
+				</p>
 			) : (
-				<ul>
+				<ul className={styles.list}>
 					{subscriptions.map((sub) => (
-						<li key={sub.id}>
-							<span>{sub.name}</span>
-							<span>¥{sub.price}</span>
-							<span>{sub.billingCycle === "monthly" ? "月額" : "年額"}</span>
-							<span>次回更新: {sub.nextRenewalDate}</span>
-							<button
-								type="button"
-								onClick={() => navigate(`/subscriptions/${sub.id}/edit`)}
-							>
-								編集
-							</button>
+						<li key={sub.id} className={styles.item}>
+							<div className={styles.info}>
+								<span className={styles.name}>{sub.name}</span>
+								<span className={styles.meta}>
+									{sub.price}
+									{sub.currency ? ` ${sub.currency.code}` : ""} /{" "}
+									{sub.billingCycle === "monthly" ? "月額" : "年額"}
+									{sub.category ? ` · ${sub.category.name}` : ""}
+								</span>
+								<span className={styles.meta}>
+									次回更新: {sub.nextRenewalDate}
+								</span>
+							</div>
+							<div className={styles.itemActions}>
+								<button
+									type="button"
+									className={styles.editButton}
+									onClick={() => navigate(`/subscriptions/${sub.id}/edit`)}
+								>
+									編集
+								</button>
+								<button
+									type="button"
+									className={styles.deleteButton}
+									onClick={() => handleDelete(sub.id)}
+								>
+									削除
+								</button>
+							</div>
 						</li>
 					))}
 				</ul>

--- a/packages/frontend/vite.config.mjs
+++ b/packages/frontend/vite.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig({
 		},
 	},
 	server: {
-		port: 3000,
+		port: 5173,
 		host: true,
 	},
 });


### PR DESCRIPTION
## 概要

サブスクリプションの一覧・登録・編集・削除画面を実装し、動作確認で発見したバグを修正しました。

## 変更内容

### 新機能
- サブスクリプション一覧画面（`SubscriptionListPage`）
- サブスクリプション登録・編集フォーム（`SubscriptionFormPage`）
  - カテゴリ選択（selectドロップダウン）
  - 通貨選択（selectドロップダウン）
  - 通知設定（更新日の何日前に通知するか）

### バグ修正
- CORSプラグインにPUT/DELETE/OPTIONSを明示的に許可（PUT・DELETE APIが動かなかった）
- ボディなしリクエスト（DELETE等）に`Content-Type: application/json`を付与しないよう修正（削除が400エラーになっていた）

### その他
- カテゴリ・通貨マスタのseedデータを追加（`packages/backend/prisma/seed.ts`）

## クローズするissue

Closes #24
Closes #25
Closes #26

## テスト済み確認項目

- [x] 一覧画面が正常に表示される
- [x] 新規登録できる（カテゴリ・通貨・通知設定含む）
- [x] 編集できる
- [x] 削除できる（確認ダイアログあり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)