### PR TITLE
feat: デモ用アカウントとサブスクリプションseedデータを追加

### DIFF
--- a/packages/backend/prisma/seed.ts
+++ b/packages/backend/prisma/seed.ts
@@ -1,6 +1,11 @@
 import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcrypt";
 
 const prisma = new PrismaClient();
+
+const SALT_ROUNDS = 10;
+const DEMO_EMAIL = "demo@example.com";
+const DEMO_PASSWORD = "Demo1234!";
 
 async function main() {
 	// カテゴリのシードデータ
@@ -40,6 +45,140 @@ async function main() {
 			update: {},
 			create: currency,
 		});
+	}
+
+	// デモアカウントのシードデータ
+	const passwordDigest = await bcrypt.hash(DEMO_PASSWORD, SALT_ROUNDS);
+	const demoUser = await prisma.user.upsert({
+		where: { email: DEMO_EMAIL },
+		update: {},
+		create: {
+			email: DEMO_EMAIL,
+			passwordDigest,
+		},
+	});
+
+	const categoryRecords = await prisma.category.findMany();
+	const currencyRecords = await prisma.currency.findMany();
+
+	const categoryIdByName = (name: string) =>
+		categoryRecords.find((c) => c.name === name)?.id ?? null;
+	const currencyIdByCode = (code: string) =>
+		currencyRecords.find((c) => c.code === code)?.id ?? null;
+
+	const demoSubscriptions = [
+		{
+			name: "Netflix",
+			price: "1980",
+			currencyCode: "JPY",
+			billingCycle: "monthly",
+			categoryName: "動画",
+			startDate: "2024-01-15",
+			nextRenewalDate: "2026-08-15",
+			isActive: true,
+		},
+		{
+			name: "Spotify",
+			price: "980",
+			currencyCode: "JPY",
+			billingCycle: "monthly",
+			categoryName: "音楽",
+			startDate: "2023-06-01",
+			nextRenewalDate: "2026-08-01",
+			isActive: true,
+		},
+		{
+			name: "iCloud+",
+			price: "400",
+			currencyCode: "JPY",
+			billingCycle: "monthly",
+			categoryName: "クラウドストレージ",
+			startDate: "2023-03-10",
+			nextRenewalDate: "2026-08-10",
+			isActive: true,
+		},
+		{
+			name: "Notion Plus",
+			price: "10",
+			currencyCode: "USD",
+			billingCycle: "monthly",
+			categoryName: "ビジネス・生産性",
+			startDate: "2024-02-01",
+			nextRenewalDate: "2026-08-01",
+			isActive: true,
+		},
+		{
+			name: "Udemy Personal Plan",
+			price: "180",
+			currencyCode: "USD",
+			billingCycle: "yearly",
+			categoryName: "学習・教育",
+			startDate: "2024-05-20",
+			nextRenewalDate: "2027-05-20",
+			isActive: true,
+		},
+		{
+			name: "Peloton App",
+			price: "12.99",
+			currencyCode: "USD",
+			billingCycle: "monthly",
+			categoryName: "フィットネス・健康",
+			startDate: "2024-04-01",
+			nextRenewalDate: "2026-08-01",
+			isActive: true,
+		},
+		{
+			name: "PlayStation Plus",
+			price: "8600",
+			currencyCode: "JPY",
+			billingCycle: "yearly",
+			categoryName: "ゲーム",
+			startDate: "2023-11-01",
+			nextRenewalDate: "2026-11-01",
+			isActive: true,
+		},
+		{
+			name: "The New York Times",
+			price: "25",
+			currencyCode: "USD",
+			billingCycle: "monthly",
+			categoryName: "ニュース・情報",
+			startDate: "2024-07-01",
+			nextRenewalDate: "2026-08-01",
+			isActive: true,
+		},
+		{
+			name: "旧クラウドストレージサービス",
+			price: "500",
+			currencyCode: "JPY",
+			billingCycle: "monthly",
+			categoryName: "その他",
+			startDate: "2022-01-01",
+			nextRenewalDate: "2026-01-01",
+			isActive: false,
+		},
+	];
+
+	for (const sub of demoSubscriptions) {
+		const existing = await prisma.subscription.findFirst({
+			where: { userId: demoUser.id, name: sub.name },
+		});
+
+		if (!existing) {
+			await prisma.subscription.create({
+				data: {
+					userId: demoUser.id,
+					name: sub.name,
+					price: sub.price,
+					currencyId: currencyIdByCode(sub.currencyCode),
+					billingCycle: sub.billingCycle,
+					startDate: new Date(sub.startDate),
+					nextRenewalDate: new Date(sub.nextRenewalDate),
+					isActive: sub.isActive,
+					categoryId: categoryIdByName(sub.categoryName),
+				},
+			});
+		}
 	}
 
 	console.log("Seed completed.");


### PR DESCRIPTION
## 概要

closes #53

レビュワーがアプリの全機能を確認できるよう、デモ用のアカウントとサブスクリプションデータを `prisma/seed.ts` に追加した。

## 変更内容

- デモアカウント（`demo@example.com`）を `bcrypt` でハッシュ化したパスワード付きで作成（`prisma.user.upsert` により再実行しても重複しない）
- 9カテゴリ・2通貨（JPY/USD）・2請求サイクル（monthly/yearly）を網羅するサブスクリプション9件を追加（うち1件は解約済み想定で `isActive: false`）
- サブスクリプションは `userId` + `name` の一致チェックにより、再実行しても重複作成されないようにした

## 動作確認

- `pnpm lint` / `tsc --noEmit` 通過
- ローカルPostgreSQLで `prisma migrate deploy` → `seed.ts` を実行し、9件のサブスクリプションが正しいカテゴリ・通貨で作成されることを確認
- seedを再実行しても重複しないことを確認
- デモアカウントで `/api/auth/login` → `/api/subscriptions` の一覧取得までAPI経由で確認

## 完了条件チェック

- [x] デモアカウントでログインしてサブスクリプションの一覧が確認できる（登録・編集・削除は既存のCRUD APIで動作するため、シードデータ投入により確認可能）
- [x] 複数カテゴリ・通貨が含まれ、アプリの機能が一通り確認できるデータが入っている