### PR TITLE
feat: フロントエンドのCI/CDをGitHub Actionsで自動化

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,45 @@
+name: Deploy Frontend
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        run: pnpm --filter frontend build
+        env:
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Sync to S3
+        run: aws s3 sync packages/frontend/dist s3://${{ secrets.S3_BUCKET_NAME }} --delete
+
+      - name: Invalidate CloudFront cache
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
## 関連Issue

close #34

## 概要

フロントエンドのビルド・S3デプロイ・CloudFrontキャッシュ無効化をGitHub Actionsで自動化した。バックエンドはRenderのGitHub連携により既に自動デプロイされているため対象外。

## 実装内容

`.github/workflows/deploy-frontend.yml` を新規作成。mainブランチへのpushをトリガーに以下を実行する。

1. checkout
2. pnpm/Node.js 22 セットアップ（backendのDockerfileと合わせたバージョン）
3. `pnpm install --frozen-lockfile`（ルートで実行）
4. `pnpm --filter frontend build`（`VITE_API_BASE_URL` をビルド時環境変数として注入）
5. AWS認証設定
6. `aws s3 sync` でS3へ同期
7. `aws cloudfront create-invalidation` でキャッシュ無効化

## 参照するGitHub Secrets（値の登録は別途必要）

- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION`
- `S3_BUCKET_NAME`
- `CLOUDFRONT_DISTRIBUTION_ID`
- `VITE_API_BASE_URL`（issue本文には明記がないが、Viteはビルド時に環境変数を静的に埋め込むため、本番のAPI URLを注入しないとフロントエンドがlocalhostを参照したままデプロイされてしまうため追加）

## 完了条件

- [x] mainにマージすると自動でフロントエンドがビルドされS3にデプロイされる
- [x] CloudFrontのキャッシュが無効化され、最新のビルド成果物が配信される

## 補足

初回マージ時は`shared`パッケージ未ビルドが原因でワークフローが失敗したため、#57 で修正。#57 マージ後にワークフロー成功・CloudFront配信への反映をブラウザで確認済み。