### PR TITLE
fix: フロントエンドデプロイ時にsharedパッケージをビルドするよう修正

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build shared package
+        run: pnpm --filter shared build
+
       - name: Build frontend
         run: pnpm --filter frontend build
         env:


### PR DESCRIPTION
## 関連Issue

related to #34

## 背景

#56 のマージ後、実際に`Deploy Frontend`ワークフローを実行したところ、`pnpm --filter frontend build`が失敗した。

```
error TS2307: Cannot find module 'shared' or its corresponding type declarations.
```

## 原因

`packages/shared/package.json`の`main`/`types`は`dist`配下（`dist/index.js`, `dist/index.d.ts`）を参照する構成になっているが、ワークフローには`shared`パッケージ自体をビルドするステップがなかったため、型定義ファイルが存在せず`tsc`がモジュール解決に失敗していた。

## 修正内容

`.github/workflows/deploy-frontend.yml`に、`pnpm --filter frontend build`の前段として`pnpm --filter shared build`を追加した。

## 動作確認

- [x] mainマージ後、GitHub Actionsのワークフローが成功することを確認
- [x] CloudFront配信URLで最新ビルドが反映されていることをブラウザで確認（`index.html`のLast-Modifiedがワークフロー実行時刻と一致）